### PR TITLE
feat: Update 'Editor's Corner' Heading Color to Match Theme (#45)

### DIFF
--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -12,7 +12,7 @@ export default function PostsPage() {
         
         {/* Page Title */}
         <div className="mb-28 text-center">
-          <h1 className="text-5xl font-bold text-gray-900">
+          <h1 className="text-5xl font-bold text-[#D9622B]">
             Editor&apos;s Corner
           </h1>
         </div>


### PR DESCRIPTION
Closes #45 
-updated css color property of the h1 heading 'Editor's Corner' to #D9622B

<img width="1913" height="657" alt="image" src="https://github.com/user-attachments/assets/e7c12472-d43f-4e08-bba6-544849f4e42c" />
